### PR TITLE
Refactor JIRA vector store builder

### DIFF
--- a/backend/rag/build_jira_vectorstore.py
+++ b/backend/rag/build_jira_vectorstore.py
@@ -2,8 +2,6 @@
 import json
 from pathlib import Path
 
-import os
-
 from dotenv import load_dotenv
 from langchain.schema import Document
 from langchain_community.vectorstores import FAISS


### PR DESCRIPTION
## Summary
- deduplicate imports in `build_jira_vectorstore.py`
- keep a single `create_vectorstore` function with optional `index_path`

## Testing
- `python -m py_compile backend/rag/build_jira_vectorstore.py`


------
https://chatgpt.com/codex/tasks/task_e_6844c11413d4832da1f39c73df89ded9