### PR TITLE
Fix create project button

### DIFF
--- a/desktop/index.html
+++ b/desktop/index.html
@@ -29,7 +29,7 @@ function AppProvider({ children }) {
   const selectProject = async (name) => {
     setProjectState(name);
     localStorage.setItem('currentProject', name);
-    try { await axios.post(`${API_BASE}/set-project`, { project: name }); } catch (e) { console.error(e); }
+    try { await axios.post(`${API_BASE}/set_project`, { key: name }); } catch (e) { console.error(e); }
   };
 
   const createProject = async (name) => {


### PR DESCRIPTION
## Summary
- wire up create project button to use `/set_project` API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6844da4109a8832dacc015e5b8cee034