### PR TITLE
Implement project creation flow

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -21,6 +21,14 @@ def set_project_route():
     set_context_field('active_project_key', key)
     return jsonify({'active_project_key': key})
 
+@app.route('/set-project', methods=['POST'])
+def set_project_dash_route():
+    project = request.get_json().get('project')
+    if not project:
+        return jsonify({'error': 'Missing project'}), 400
+    set_context_field('active_project_key', project)
+    return jsonify({'active_project_key': project})
+
 @app.route('/set_assignee', methods=['POST'])
 def set_assignee_route():
     assignee = request.get_json().get('assignee')

--- a/desktop/index.html
+++ b/desktop/index.html
@@ -29,7 +29,7 @@ function AppProvider({ children }) {
   const selectProject = async (name) => {
     setProjectState(name);
     localStorage.setItem('currentProject', name);
-    try { await axios.post(`${API_BASE}/set_project`, { key: name }); } catch (e) { console.error(e); }
+    try { await axios.post(`${API_BASE}/set-project`, { project: name }); } catch (e) { console.error(e); }
   };
 
   const createProject = async (name) => {
@@ -60,12 +60,22 @@ function AppProvider({ children }) {
 }
 
 function WelcomeScreen({ onCreate, onSelect }) {
+  const [projectName, setProjectName] = useState('');
+  const handleCreate = () => {
+    if (projectName.trim()) onCreate(projectName.trim());
+  };
   return (
     <div className="flex flex-col items-center justify-center h-full bg-gray-100">
-      <h1 className="text-4xl font-bold mb-8">Welcome to Sidekick</h1>
+      <h1 className="text-4xl font-bold mb-4">Welcome to Sidekick</h1>
+      <input
+        className="border p-2 rounded mb-4 w-64"
+        placeholder="Project name"
+        value={projectName}
+        onChange={e => setProjectName(e.target.value)}
+      />
       <div className="space-x-4">
         <button className="px-4 py-2 bg-blue-500 text-white rounded" onClick={onSelect}>Select Existing Project</button>
-        <button className="px-4 py-2 bg-green-500 text-white rounded" onClick={onCreate}>Create New Project</button>
+        <button className="px-4 py-2 bg-green-500 text-white rounded" onClick={handleCreate}>Create New Project</button>
       </div>
     </div>
   );
@@ -145,8 +155,7 @@ function App() {
   const [chatHistory, setChatHistory] = useState([]);
   const [chatLoading, setChatLoading] = useState(false);
 
-  const handleCreateProject = async () => {
-    const name = prompt('Enter new project name');
+  const handleCreateProject = async (name) => {
     if (name) await createProject(name);
   };
 


### PR DESCRIPTION
## Summary
- add REST endpoint `/set-project` so frontend can set project
- add input-based project creation screen
- update context to post to `/set-project`

## Testing
- `python -m py_compile backend/server.py`

------
https://chatgpt.com/codex/tasks/task_e_6844dc2f839c832dababb026587c8261