### PR TITLE
Add Jira connect button

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ Run the assistant via CLI or start the HTTP API.
 
 ### Environment
 
-Create a `.env` file with:
+You can either set Jira credentials in a `.env` file or connect at runtime.
+
+To use environment variables create `.env` with:
 
 ```
 JIRA_URL=<https://your-domain.atlassian.net>
@@ -36,6 +38,10 @@ JIRA_EMAIL=<your@email>
 JIRA_API_TOKEN=<token>
 JIRA_DOMAIN=<your-domain.atlassian.net>
 ```
+
+Alternatively call the `/connect_jira` endpoint (or the "Connect to Jira" button
+in the web UI) and provide your Jira URL, email and API token. Credentials are
+stored in `backend/jira_credentials.json`.
 
 ### Build Memory and Vector Store
 
@@ -70,6 +76,8 @@ POST `/sidekick` with `{ "notes": "..." }` to get a response.
 ## Frontend
 
 A minimal web interface is provided under `frontend/`.
+Use the **Connect to Jira** button in the UI to supply your credentials if you
+haven't created a `.env` file.
 
 ## Desktop Electron App
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 
 from .sidekick import sidekick_core
 from .context.context_memory import set_context_field
+from .utils.credentials import save_credentials
 
 app = Flask(__name__)
 CORS(app)
@@ -36,6 +37,17 @@ def set_assignee_route():
         return jsonify({'error': 'Missing assignee'}), 400
     set_context_field('default_assignee', assignee)
     return jsonify({'default_assignee': assignee})
+
+
+@app.route('/connect_jira', methods=['POST'])
+def connect_jira_route():
+    data = request.get_json()
+    required = ['url', 'email', 'api_token', 'domain']
+    if not all(data.get(k) for k in required):
+        return jsonify({'error': 'Missing Jira credentials'}), 400
+
+    save_credentials(data['url'], data['email'], data['api_token'], data['domain'])
+    return jsonify({'success': True})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/backend/utils/__init__.py
+++ b/backend/utils/__init__.py
@@ -1,0 +1,4 @@
+from .config import require_env_vars
+from .jira_utils import create_ticket, update_ticket, comment_on_ticket
+from .get_info_from_jira import save_snapshot, build_full_snapshot
+from .credentials import load_credentials, save_credentials

--- a/backend/utils/credentials.py
+++ b/backend/utils/credentials.py
@@ -1,0 +1,41 @@
+import os
+import json
+from pathlib import Path
+
+CREDS_PATH = Path(__file__).resolve().parent.parent / "jira_credentials.json"
+
+
+def load_credentials():
+    """Load Jira credentials from env vars or stored file."""
+    url = os.getenv("JIRA_URL")
+    email = os.getenv("JIRA_EMAIL")
+    token = os.getenv("JIRA_API_TOKEN")
+    domain = os.getenv("JIRA_DOMAIN")
+
+    if all([url, email, token, domain]):
+        return {
+            "url": url,
+            "email": email,
+            "api_token": token,
+            "domain": domain,
+        }
+
+    if CREDS_PATH.exists():
+        with open(CREDS_PATH) as f:
+            data = json.load(f)
+            return data
+    return None
+
+
+def save_credentials(url: str, email: str, api_token: str, domain: str) -> None:
+    CREDS_PATH.write_text(
+        json.dumps(
+            {
+                "url": url,
+                "email": email,
+                "api_token": api_token,
+                "domain": domain,
+            },
+            indent=2,
+        )
+    )

--- a/backend/utils/get_info_from_jira.py
+++ b/backend/utils/get_info_from_jira.py
@@ -5,14 +5,17 @@ from pathlib import Path
 import requests
 
 from dotenv import load_dotenv
-from .config import require_env_vars
-
+from .credentials import load_credentials
 load_dotenv()
-require_env_vars(["JIRA_EMAIL", "JIRA_API_TOKEN", "JIRA_DOMAIN"])
+creds = load_credentials()
+if not creds:
+    raise EnvironmentError(
+        "Jira credentials not provided. Set env vars or use /connect_jira endpoint."
+    )
 
-JIRA_EMAIL = os.getenv("JIRA_EMAIL")
-JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN")
-JIRA_DOMAIN = os.getenv("JIRA_DOMAIN")
+JIRA_EMAIL = creds["email"]
+JIRA_API_TOKEN = creds["api_token"]
+JIRA_DOMAIN = creds["domain"]
 JIRA_HEADERS = { "Accept": "application/json" }
 JIRA_AUTH = (JIRA_EMAIL, JIRA_API_TOKEN)
 

--- a/backend/utils/jira_utils.py
+++ b/backend/utils/jira_utils.py
@@ -1,14 +1,18 @@
 import os
 from dotenv import load_dotenv
 from jira import JIRA
-from .config import require_env_vars
+from .credentials import load_credentials
 
 load_dotenv()
-require_env_vars(["JIRA_URL", "JIRA_EMAIL", "JIRA_API_TOKEN"])
+creds = load_credentials()
+if not creds:
+    raise EnvironmentError(
+        "Jira credentials not provided. Set env vars or use /connect_jira endpoint."
+    )
 
-JIRA_URL = os.getenv("JIRA_URL")
-JIRA_EMAIL = os.getenv("JIRA_EMAIL")
-JIRA_API_TOKEN = os.getenv("JIRA_API_TOKEN")
+JIRA_URL = creds["url"]
+JIRA_EMAIL = creds["email"]
+JIRA_API_TOKEN = creds["api_token"]
 
 jira = JIRA(
     server=JIRA_URL,

--- a/frontend/main/main.html
+++ b/frontend/main/main.html
@@ -9,6 +9,7 @@
 <body>
   <div id="chat-container">
     <textarea id="input" placeholder="Paste meeting notes or ask Sidekick..."></textarea>
+    <button onclick="connectJira()">Connect to Jira</button>
     <button onclick="sendMessage()">Create Tickets</button>
     <div id="response"></div>
   </div>

--- a/frontend/main/main.js
+++ b/frontend/main/main.js
@@ -5,7 +5,7 @@ async function sendMessage() {
   // Show loading
   responseDiv.innerHTML = "<div class='chat-bubble'>🤖 Thinking...</div>";
 
-  const response = await fetch("http://localhost:5000/parse_notes", {
+  const response = await fetch("http://localhost:5000/sidekick", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ notes: input })
@@ -21,6 +21,23 @@ async function sendMessage() {
   </div>
 `).join('');
 
+}
+
+async function connectJira() {
+  const url = prompt("Jira URL (e.g. https://your.atlassian.net)");
+  const email = prompt("Email");
+  const token = prompt("API Token");
+  if (!url || !email || !token) {
+    alert("Missing information");
+    return;
+  }
+  const domain = url.replace(/^https?:\/\//, "");
+  await fetch("http://localhost:5000/connect_jira", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url, email, api_token: token, domain })
+  });
+  alert("Jira connected");
 }
 
 function formatResult(result) {


### PR DESCRIPTION
## Summary
- add a simple Jira credential store and API
- expose POST `/connect_jira` for saving credentials
- update utils to load saved credentials
- update frontend with *Connect to Jira* button
- document how to connect to Jira

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6844dfad0ddc832db8d0f80d893f3056